### PR TITLE
Feature/use css variables for colors in the base components

### DIFF
--- a/artifacts/styles/common.css
+++ b/artifacts/styles/common.css
@@ -6,6 +6,20 @@
     --btn-primary-enabled-bg-color: #735CFE;
     --btn-primary-enabled-color: #FFFFFF;
     --content-color: #313C59;
+
+    /* Required to be present in the project using the components */
+    --white-color: #FFFFFF;
+    --black-color: #000000;
+
+    --grey-color: #606c8b;
+    --grey-dark-color: #313c59;
+
+    --violet-color: #E339FF;
+    --red-color: #ff5f5f;
+
+    /* Project specific theme colors */
+    --primary-color: #00cad9;
+    --primary-light-color: rgba(0, 202, 217, 25);
 }
 
 html {

--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -113,14 +113,14 @@ function onClick() {
   }
 
   &.primary {
-    color: #fff;
-    border: solid 1px #00cad9;
-    background-color: #00cad9;
+    color: white;
+    border: solid 1px var(--primary-color);
+    background-color: var(--primary-color);
     box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 
     &:focus {
       outline: none;
-      box-shadow: 0 0 0 2px #606c8b;
+      box-shadow: 0 0 0 2px var(--grey-color);
     }
 
     &.disabled {
@@ -129,20 +129,20 @@ function onClick() {
   }
 
   &.secondary {
-    color: #fff;
-    border: solid 1px #606c8b;
-    background-color: #606c8b;
+    color: white;
+    border: solid 1px var(--grey-color);
+    background-color: var(--grey-color);
     box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 
     &:focus {
       outline: none;
-      box-shadow: 0 0 0 2px #00cad9;
+      box-shadow: 0 0 0 2px white;
     }
 
     &.disabled {
-      background-color: #fff;
-      color: #606c8b;
-      border: solid 1px #606c8b;
+      background-color: white;
+      color: var(--grey-color);
+      border: solid 1px var(--grey-color);
     }
   }
 

--- a/src/components/BaseCard.vue
+++ b/src/components/BaseCard.vue
@@ -77,7 +77,7 @@ const isMultiColumn = computed(() => slots.right && slots.left)
   align-items: center;
   font-size: 14px;
   line-height: 19px;
-  color: #606c8b;
+  color: var(--grey-color);
 }
 </style>
 
@@ -120,7 +120,7 @@ const isMultiColumn = computed(() => slots.right && slots.left)
   font-weight: bold;
   font-size: 14px;
   line-height: 19px;
-  color: #606c8b;
+  color: var(--grey-color);
 }
 
 .body {

--- a/src/components/BaseInput.vue
+++ b/src/components/BaseInput.vue
@@ -142,7 +142,7 @@ const {
     display: block;
     width: 100%;
     margin-top: 0;
-    border: 1px solid #606c8b;
+    border: 1px solid var(--grey-color);
     border-radius: 5px;
     padding: 9px 14px;
     font-size: 14px;
@@ -150,7 +150,7 @@ const {
 
     &:focus {
       outline: none;
-      border: 1px solid #00cad9;
+      border: 1px solid var(--primary-color);
     }
 
     &::placeholder {
@@ -166,14 +166,14 @@ const {
     }
 
     &.invalid {
-      border-color: #ff5f5f;
+      border-color: var(--red-color);
     }
   }
 
   &__error {
     margin: 5px 0 4px 1px;
     font-size: 12px;
-    color: #ff5f5f;
+    color: var(--red-color);
     font-weight: 600;
   }
 

--- a/src/components/BaseLoginInput.vue
+++ b/src/components/BaseLoginInput.vue
@@ -171,7 +171,7 @@ const {
     display: block;
     font-size: 12px;
     line-height: 16px;
-    color: #606c8b;
+    color: var(--grey-color);
     text-transform: uppercase;
   }
 
@@ -202,14 +202,14 @@ const {
     }
 
     &.invalid {
-      border-color: #ff5f5f;
+      border-color: var(--red-color);
     }
   }
 
   &__error {
     margin: 5px 0 4px 1px;
     font-size: 12px;
-    color: #ff5f5f;
+    color: var(--red-color);
   }
 
   .eye-icon {

--- a/src/components/CircleSpinner.vue
+++ b/src/components/CircleSpinner.vue
@@ -7,7 +7,7 @@
   >
     <div
       class="dot-spin"
-      :class="[theme === EOverlayTheme.light ? 'text-host-console' : 'text-white']"
+      :class="[theme === EOverlayTheme.light ? 'color-primary' : 'color-white']"
       data-test-circle-spinner-dots
     />
   </div>
@@ -113,12 +113,12 @@ defineProps({
   }
 }
 
-.text-white {
-  color: #fff;
+.color-white {
+  color: white;
 }
 
-.text-host-console {
-  color: #00cad9;
+.color-primary {
+  color: var(--primary-color);
 }
 </style>
 

--- a/src/components/FlatSpinner.vue
+++ b/src/components/FlatSpinner.vue
@@ -86,15 +86,15 @@ const computedScale = computed(() => ({
 }
 
 .loader-dot.primary {
-  background-color: #00cad9;
+  background-color: var(--primary-color);
 }
 
 .loader-dot.secondary {
-  background-color: #606c8b;
+  background-color: var(--grey-color);
 }
 
 .loader-dot.white {
-  background-color: #fff;
+  background-color: white;
 }
 
 @keyframes grow {


### PR DESCRIPTION
This PR uses css variables to allow different theme to be used per app:

We need to import the `artifacts/styles/common.css` and overwrite the variables we want to change (only `--primary-color` for now) to see the buttons and inputs having proper colors.
