### PR TITLE
Feature/Add BaseLinkButton component and adjust BaseCard component

### DIFF
--- a/src/components/BaseCard.vue
+++ b/src/components/BaseCard.vue
@@ -18,12 +18,13 @@
 
 		<div class="card-content">
 			<div
-				v-if="isLoading || isError"
+				v-if="isLoading || isError || isDisabled"
 				class="card-overlay"
+				:class="{ 'is-disabled': isDisabled }"
 			>
 				<CircleSpinner v-if="isLoading" class="card-spinner" />
 				<div
-					v-else
+					v-else-if="isError"
 					class="error-message"
 				>
 					<p>Sorry, we couldn’t fetch this data.</p>
@@ -76,6 +77,11 @@ import { EButtonType } from '../types/ui'
 const slots = useSlots()
 
 defineProps({
+	isDisabled: {
+		type: Boolean,
+		default: false
+	},
+
 	isLoading: {
 		type: Boolean,
 		default: false
@@ -121,15 +127,15 @@ const isMultiColumn = computed(() => slots.right && slots.left)
 .card {
   display: flex;
   flex-direction: column;
-  margin-right: 30px;
   flex-basis: 33%;
   background-color: white;
   box-shadow: 0 4px 20px #eceef1;
   border-radius: 12px;
 }
 
-.card:last-child {
-  margin-right: 14px;
+.is-disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .card-content {
@@ -208,6 +214,7 @@ const isMultiColumn = computed(() => slots.right && slots.left)
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	border-radius: 12px;
 	width: 100%;
 	height: 100%;
 	background-color: var(--white-color);
@@ -227,10 +234,6 @@ const isMultiColumn = computed(() => slots.right && slots.left)
 @media screen and (max-width: 1050px) {
   .card {
     margin-bottom: 28px;
-    margin-right: 0;
-  }
-
-  .card:last-child {
     margin-right: 0;
   }
 

--- a/src/components/BaseLinkButton.vue
+++ b/src/components/BaseLinkButton.vue
@@ -1,0 +1,94 @@
+<template>
+	<router-link
+		:to="to"
+		class="base-link-button"
+		:class="[{ 'disabled': isDisabled, 'with-arrow': withArrow }]"
+		:style="{ backgroundColor: color }"
+	>
+		<component
+			v-if="icon"
+			:is="icon"
+			class="base-link-button__icon"
+		/>
+
+		{{ label }}
+
+		<slot />
+
+		<RightChevronIcon
+			v-if="withArrow"
+			class="base-link-button__right-chevron-icon"
+			color="#606C8B"
+		/>
+	</router-link>
+</template>
+
+<script setup>
+import RightChevronIcon from './icons/RightChevronIcon.vue'
+
+defineProps({
+	to: {
+		type: String,
+		required: true
+	},
+
+	isDisabled: {
+		type: Boolean,
+		default: false
+	},
+
+	icon: {
+		type: Object,
+		default: () => {}
+	},
+
+	label: {
+		type: String,
+		required: true
+	},
+
+	color: {
+		type: String,
+		default: 'rgba(176, 236, 240, 0.72)'
+	},
+
+	withArrow: {
+		type: Boolean,
+		default: false
+	}
+})
+</script>
+
+<style lang="scss" scoped>
+.base-link-button {
+	height: 52px;
+	padding: 0 14px 0 40px;
+	border-radius: 5px;
+	font-weight: bold;
+	font-size: 16px;
+	line-height: 22px;
+	color: var(--grey-dark-color);
+	display: flex;
+	align-items: center;
+	text-decoration: none;
+
+	&.with-arrow {
+		padding-left: 50px;
+	}
+
+	&.disabled {
+		opacity: 0.3;
+		cursor: not-allowed;
+	}
+
+	&__icon {
+		margin-right: 14px;
+	}
+
+	&__right-chevron-icon {
+		margin-left: auto;
+		transform: scale(1.8);
+	}
+}
+
+</style>


### PR DESCRIPTION
This PR:

- adds a link button used in our apps:

<img width="477" alt="Screenshot 2022-09-21 at 16 11 44" src="https://user-images.githubusercontent.com/17565389/191527496-f6f80385-d134-4948-b60b-9b630f45e09b.png">

<img width="301" alt="Screenshot 2022-09-21 at 16 11 53" src="https://user-images.githubusercontent.com/17565389/191527525-c5f34a4e-4f2d-4123-a97d-226ceab63dad.png">

- updates BaseCard component by removing the styles (margins) and allow us to control the card margins from the parent components. It also 
- adds disabled state for the card