### PR TITLE
add enter keyboard event to publisher name event

### DIFF
--- a/src/components/NameSetterModal.vue
+++ b/src/components/NameSetterModal.vue
@@ -7,7 +7,12 @@
       <p>
         {{ body }}
       </p>
-      <input type="text" id="publisher-name" v-model="name" class="modal-input" data-testid='name-setter-modal-input' placeholder="Enter Account Display Name " >
+      <input type="text" id="publisher-name"
+        v-model="name"
+        @keyup.enter.native="!confirmDisabled && onSaveName()"
+        class="modal-input"
+        data-testid='name-setter-modal-input'
+        placeholder="Enter Account Display Name " >
     </div>
     <div class='footer'>
       <div class='buttons'>


### PR DESCRIPTION
Close the name setter modal when the user presses enter while entering the publisher name.

![image](https://user-images.githubusercontent.com/16830873/197057620-dfd130b1-a014-4452-9041-7750834ce99b.png)
