### PR TITLE
Changes to HAppCard for publisher portal hApps view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bug in useHoloStore that was failing to update `appInfo` and `isReady` on initialization. [(#29)]
 
 ### Changed
+- Modified HAppCard, HAppCardUsage, and HAppImage to support publisher portal hApp view [(#43)]
 - Updated Identicon component to have an api usable by all 3 client UIs. [(#15)]
 - Identity modal must be closed by clicking I Understand (removed option to click outside dialog to close) [(#18)]
 - Add button id for I Understand dialog button on identity modal [(#19)]
@@ -21,3 +22,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [(#18)]: https://github.com/Holo-Host/ui-common-library/pull/18
 [(#19)]: https://github.com/Holo-Host/ui-common-library/pull/19
 [(#29)]: https://github.com/Holo-Host/ui-common-library/pull/29
+[(#43)]: https://github.com/Holo-Host/ui-common-library/pull/43

--- a/artifacts/styles/common.css
+++ b/artifacts/styles/common.css
@@ -22,6 +22,7 @@
     --green-color: #21BE98;
     --green-light-color: #CBFFE3;
     --yellow-light-color: #ffe871;
+    --yellow-color: #FFA800;
 
     /* Project specific theme colors */
     --primary-color: #735CFE;

--- a/src/components/BaseChip.vue
+++ b/src/components/BaseChip.vue
@@ -21,7 +21,7 @@ const props = defineProps({
     type: Number,
     default: EChipType.info,
     validator(value) {
-      return [EChipType.info, EChipType.danger, EChipType.success].includes(value)
+      return [EChipType.info, EChipType.danger, EChipType.success, EChipType.warning].includes(value)
     }
   },
 
@@ -37,6 +37,7 @@ const kChipTypeClass = {
   [EChipType.info]: `${kBaseClass}__info`,
   [EChipType.danger]: `${kBaseClass}__danger`,
   [EChipType.success]: `${kBaseClass}__success`,
+  [EChipType.warning]: `${kBaseClass}__warning`,
   [EChipType.custom]: `${kBaseClass}__custom`
 }
 
@@ -78,6 +79,11 @@ const computedCustomStyle = computed(() => {
   &__success {
     background-color: var(--green-light-color);
     color: var(--green-color);
+  }
+
+  &__warning {
+    background-color: var(--yellow-light-color);
+    color: var(--yellow-color);
   }
 }
 </style>

--- a/src/components/HAppCard.vue
+++ b/src/components/HAppCard.vue
@@ -27,9 +27,21 @@
           {{ happ.name }}
 
           <BaseChip
-            v-if="happ.isPaused"
+            v-if="happ.is_draft || happ.isDraft"
+            :label="$t('$.draft')"
+            :type="EChipType.warning"
+          />
+
+          <BaseChip
+            v-else-if="happ.is_paused || happ.isPaused"
             :label="$t('$.paused')"
-            :type="EChipType.info"
+            :type="EChipType.danger"
+          />
+
+          <BaseChip
+            v-else
+            :label="$t('$.published')"
+            :type="EChipType.success"
           />
 
           <ArrowIcon class="happ-card__name-arrow-icon" />

--- a/src/components/HAppCard.vue
+++ b/src/components/HAppCard.vue
@@ -27,11 +27,6 @@
           {{ happ.name }}
 
           <slot name="status-chip">
-            <BaseChip
-              v-if="happ.isPaused"
-              :label="$t('$.paused')"
-              :type="EChipType.info"
-            />
           </slot>
 
           <slot name="link-icon">
@@ -54,10 +49,8 @@
 
 <script setup>
 import { computed } from 'vue'
-import { EChipType } from '../types/ui'
 import { formatCurrency } from '../utils/numbers'
 import BaseCard from './BaseCard.vue'
-import BaseChip from './BaseChip.vue'
 import HAppCardUsage from './HAppCardUsage.vue'
 import HAppImage from './HAppImage.vue'
 import ArrowIcon from './icons/ArrowIcon.vue'

--- a/src/components/HAppCard.vue
+++ b/src/components/HAppCard.vue
@@ -27,21 +27,9 @@
           {{ happ.name }}
 
           <BaseChip
-            v-if="happ.is_draft || happ.isDraft"
-            :label="$t('$.draft')"
-            :type="EChipType.warning"
-          />
-
-          <BaseChip
-            v-else-if="happ.is_paused || happ.isPaused"
-            :label="$t('$.paused')"
-            :type="EChipType.danger"
-          />
-
-          <BaseChip
-            v-else-if="isPublished"
-            :label="$t('$.published')"
-            :type="EChipType.success"
+            v-if="isStateChipVisible"
+            :label="$t(stateChipProps.label)"
+            :type="stateChipProps.type"
           />
 
           <slot name="link-icon">
@@ -99,6 +87,40 @@ const earnings = computed(() =>
     ? formatCurrency(Number(props.happ.last7daysEarnings))
     : '--'
 )
+
+const isDraft = computed(() => props.happ.is_draft || props.happ.isDraft)
+
+const isStateChipVisible = computed(() => isDraft.value || props.happ?.is_paused || props.happ?.isPaused || props.isPublished)
+
+const stateChipProps = computed(() => {
+  if (isDraft.value) {
+    return {
+      label: '$.draft',
+      type: EChipType.warning
+    }
+  }
+
+  if (props.happ?.is_paused) { // The happ model from publisher portal uses is_paused and paused state is displayed as a red danger chip
+    return {
+      label: '$.paused',
+      type: EChipType.danger
+    }
+  }
+
+  if (props.happ?.isPaused) { // The happ model from host console uses isPaused and paused state is displayed as a blue info chip
+    return {
+      label: '$.paused',
+      type: EChipType.info
+    }
+  }
+
+  if (props.isPublished) {
+    return {
+      label: '$.published',
+      type: EChipType.success
+    }    
+  }
+})
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/HAppCard.vue
+++ b/src/components/HAppCard.vue
@@ -44,7 +44,9 @@
             :type="EChipType.success"
           />
 
-          <ArrowIcon class="happ-card__name-arrow-icon" />
+          <slot name="link-icon">
+            <ArrowIcon class="happ-card__name-arrow-icon" />
+          </slot>
         </div>
 
         <div class="happ-card__earnings disabled">

--- a/src/components/HAppCard.vue
+++ b/src/components/HAppCard.vue
@@ -39,7 +39,7 @@
           />
 
           <BaseChip
-            v-else
+            v-else-if="isPublished"
             :label="$t('$.published')"
             :type="EChipType.success"
           />
@@ -86,7 +86,12 @@ const props = defineProps({
   emptyCardLabel: {
     type: String,
     default: ''
-  }
+  },
+
+  isPublished: {
+    type: Boolean,
+    default: false
+  },
 })
 
 const earnings = computed(() =>

--- a/src/components/HAppCard.vue
+++ b/src/components/HAppCard.vue
@@ -26,11 +26,13 @@
         <div class="happ-card__name">
           {{ happ.name }}
 
-          <BaseChip
-            v-if="isStateChipVisible"
-            :label="$t(stateChipProps.label)"
-            :type="stateChipProps.type"
-          />
+          <slot name="status-chip">
+            <BaseChip
+              v-if="happ.isPaused"
+              :label="$t('$.paused')"
+              :type="EChipType.info"
+            />
+          </slot>
 
           <slot name="link-icon">
             <ArrowIcon class="happ-card__name-arrow-icon" />
@@ -74,12 +76,7 @@ const props = defineProps({
   emptyCardLabel: {
     type: String,
     default: ''
-  },
-
-  isPublished: {
-    type: Boolean,
-    default: false
-  },
+  }
 })
 
 const earnings = computed(() =>
@@ -88,39 +85,6 @@ const earnings = computed(() =>
     : '--'
 )
 
-const isDraft = computed(() => props.happ.is_draft || props.happ.isDraft)
-
-const isStateChipVisible = computed(() => isDraft.value || props.happ?.is_paused || props.happ?.isPaused || props.isPublished)
-
-const stateChipProps = computed(() => {
-  if (isDraft.value) {
-    return {
-      label: '$.draft',
-      type: EChipType.warning
-    }
-  }
-
-  if (props.happ?.is_paused) { // The happ model from publisher portal uses is_paused and paused state is displayed as a red danger chip
-    return {
-      label: '$.paused',
-      type: EChipType.danger
-    }
-  }
-
-  if (props.happ?.isPaused) { // The happ model from host console uses isPaused and paused state is displayed as a blue info chip
-    return {
-      label: '$.paused',
-      type: EChipType.info
-    }
-  }
-
-  if (props.isPublished) {
-    return {
-      label: '$.published',
-      type: EChipType.success
-    }    
-  }
-})
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/HAppCardUsage.vue
+++ b/src/components/HAppCardUsage.vue
@@ -26,7 +26,7 @@ const props = defineProps({
 const items = computed(() => {
   return [
     {
-      value: presentMicroSeconds(props.happ.usage.cpu),
+      value: presentMicroSeconds(props.happ.usage?.cpu),
       unit: t('$.cpu'),
       isDisabled: true
     },
@@ -36,7 +36,7 @@ const items = computed(() => {
       isDisabled: true
     },
     {
-      value: presentBytes(props.happ.usage.bandwidth),
+      value: presentBytes(props.happ.usage?.bandwidth),
       unit: t('$.bandwidth'),
       isDisabled: false
     }

--- a/src/components/HAppImage.vue
+++ b/src/components/HAppImage.vue
@@ -1,7 +1,7 @@
 <template>
   <img
-    v-if="happ.logoUrl"
-    :src="happ.logoUrl"
+    v-if="happ.logoUrl || happ.logo_url"
+    :src="happ.logoUrl || happ.logo_url"
     alt="app-logo"
     :style="style"
     class="happ-image"

--- a/src/components/SortByDropdown.vue
+++ b/src/components/SortByDropdown.vue
@@ -1,0 +1,85 @@
+<template>
+  <div class="sort-by-dropdown">
+    <div
+      class="sort-by-dropdown__label"
+      :class="{ 'sort-by-dropdown--disabled': isDisabled }"
+    >
+      {{ $t('$.sort_by') }}:&nbsp;
+    </div>
+    <select
+      :value="value"
+      class="sort-by-dropdown__sort"
+      :class="{ 'sort-by-dropdown--disabled': isDisabled }"
+      @change="onChange"
+    >
+      <option
+        v-for="option in options"
+        :key="option.value"
+        :value="option.value"
+      >
+        {{ option.label }}
+      </option>
+    </select>
+  </div>
+</template>
+
+<script setup>
+import { kSortOptions } from './constants/sortOptions'
+
+defineProps({
+  value: {
+    type: String,
+    required: true
+  },
+
+  isDisabled: {
+    type: Boolean,
+    default: false
+  },
+
+  options: {
+    type: Array,
+    default: Object.values(kSortOptions)
+  }
+})
+
+const emit = defineEmits(['update:value'])
+
+const onChange = (e) => {
+  emit('update:value', e.target.value)
+}
+</script>
+
+<style lang="scss">
+.sort-by-dropdown {
+  position: relative;
+  display: flex;
+  align-items: center;
+  user-select: none;
+
+  &__label {
+    color: var(--grey-color);
+    font-size: 12px;
+    margin-left: 30px;
+    margin-right: 2px;
+  }
+
+  &__sort {
+    appearance: none;
+    border: none;
+    background-color: transparent;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--grey-dark-color);
+    padding: 4px 16px 4px 4px;
+    background-image: url(/images/chevron.svg);
+    background-repeat: no-repeat;
+    background-position: right;
+  }
+
+  &--disabled {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+}
+</style>

--- a/src/components/constants/sortOptions.js
+++ b/src/components/constants/sortOptions.js
@@ -1,0 +1,10 @@
+export const kSortOptions = {
+  alphabetical: {
+    label: 'Alphabetical',
+    value: 'alphabetical'
+  },
+  earnings: {
+    label: 'Highest earnings',
+    value: 'earnings'
+  }
+}

--- a/src/components/icons/HappsIcon.vue
+++ b/src/components/icons/HappsIcon.vue
@@ -1,0 +1,37 @@
+<template>
+  <Icon :fill="color" class='icon'>
+    <path :fill-opacity="fillOpacity" d="M17.3432 1H2.65684C1.74179 1 1 1.74179 1 2.65684V7.34316C1 8.25821 1.74179 9 2.65684 9H17.3432C18.2582 9 19 8.25821 19 7.34316V2.65684C19 1.74179 18.2582 1 17.3432 1Z"  stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path :fill-opacity="fillOpacity" d="M17.3432 9H2.65684C1.74179 9 1 9.74179 1 10.6568V15.3432C1 16.2582 1.74179 17 2.65684 17H17.3432C18.2582 17 19 16.2582 19 15.3432V10.6568C19 9.74179 18.2582 9 17.3432 9Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  </Icon>
+</template>
+  
+<script>
+
+import Icon from './Icon.vue'
+
+export default {
+  name: 'HappsIcon',
+  components: {
+    Icon
+  },
+  props: {
+    disabled: {type: Boolean, default: false },
+    color: {
+      type: String,
+      default: "#21BE98"
+    }
+  },
+  computed: {
+    fillOpacity () {
+      return this.disabled ? '0.18' : '1'
+    }
+  }  
+}
+</script>
+
+<style scoped>
+.icon {
+  width: 26px;
+  height: 26px;
+}
+</style>  

--- a/src/components/icons/HappsIcon.vue
+++ b/src/components/icons/HappsIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <Icon class='icon' :fill="white">
+  <Icon class='icon' :fill="color">
     <path d="M19.3432 4H4.65684C3.74179 4 3 4.74179 3 5.65684V10.3432C3 11.2582 3.74179 12 4.65684 12H19.3432C20.2582 12 21 11.2582 21 10.3432V5.65684C21 4.74179 20.2582 4 19.3432 4Z" fill="none" :stroke="color" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     <path d="M19.3432 12H4.65684C3.74179 12 3 12.7418 3 13.6568V18.3432C3 19.2582 3.74179 20 4.65684 20H19.3432C20.2582 20 21 19.2582 21 18.3432V13.6568C21 12.7418 20.2582 12 19.3432 12Z" fill="none" :stroke="color" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
     <path d="M7 8V8.01" :stroke="color" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/src/components/icons/HappsIcon.vue
+++ b/src/components/icons/HappsIcon.vue
@@ -1,9 +1,13 @@
 <template>
-  <Icon :fill="color" class='icon'>
-    <path :fill-opacity="fillOpacity" d="M17.3432 1H2.65684C1.74179 1 1 1.74179 1 2.65684V7.34316C1 8.25821 1.74179 9 2.65684 9H17.3432C18.2582 9 19 8.25821 19 7.34316V2.65684C19 1.74179 18.2582 1 17.3432 1Z"  stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-    <path :fill-opacity="fillOpacity" d="M17.3432 9H2.65684C1.74179 9 1 9.74179 1 10.6568V15.3432C1 16.2582 1.74179 17 2.65684 17H17.3432C18.2582 17 19 16.2582 19 15.3432V10.6568C19 9.74179 18.2582 9 17.3432 9Z" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  <Icon class='icon' :fill="white">
+    <path d="M19.3432 4H4.65684C3.74179 4 3 4.74179 3 5.65684V10.3432C3 11.2582 3.74179 12 4.65684 12H19.3432C20.2582 12 21 11.2582 21 10.3432V5.65684C21 4.74179 20.2582 4 19.3432 4Z" fill="none" :stroke="color" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M19.3432 12H4.65684C3.74179 12 3 12.7418 3 13.6568V18.3432C3 19.2582 3.74179 20 4.65684 20H19.3432C20.2582 20 21 19.2582 21 18.3432V13.6568C21 12.7418 20.2582 12 19.3432 12Z" fill="none" :stroke="color" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M7 8V8.01" :stroke="color" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M7 16V16.01" :stroke="color" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+
   </Icon>
 </template>
+  
   
 <script>
 

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -8,6 +8,7 @@ const translations = {
     close: 'Close',
     cpu: 'CPU',
     dont_show_this_message_again: "Don't show this message again",
+    draft: 'Draft',
     error: 'Error',
     errors: {
       email: 'Please enter a valid email.',
@@ -46,6 +47,7 @@ const translations = {
     network: 'Network',
     page_not_found: "Hmm... We're unable to find that page.",
     paused: 'Paused',
+    published: 'Published',
     rows_per_page: 'Rows per page',
     search: 'Search',
     sort_by: 'Sort by',

--- a/src/types/ui.js
+++ b/src/types/ui.js
@@ -43,6 +43,7 @@ export const EChipType = {
   info: 0,
   danger: 1,
   success: 2,
+  warning: 3,
   custom: 99
 }
 


### PR DESCRIPTION
This PR makes changes to the shared HAppCard, HAppCardImage, and HAppCardUsasge components to support the hApps view in publisher portal.

Some possible breaking changes to host console ui:

1. Changed the color of the paused status chip. I think I remember C saying that we wanted the colors to match but if not I'll need to change this logic. 
2. I also added published and draft states but this shouldn't affect host console as they are only rendered if the attribute exists.

![image](https://user-images.githubusercontent.com/16830873/197592095-e36c4f75-cf55-4ac2-9184-7f4b23d8bf2e.png)

3. Added prop isPublished to HAppCard that defaults to false. In publisher portal a happ that isn't paused or in draft is considered published. Added a prop so this will only be rendered in publisher portal.
4. There are some slight differences in the shape of hApp data structure between publisher portal and host console. I modified the vue components to work with either shape.
5. I swipped the SortByDropDown and SortByOptions from host console and added them to ui-common-library since they can be used in both projects.