### PR TITLE
web-sdk v0.6.8-prerelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@holo-host/identicon": "^0.1.0",
-    "@holo-host/web-sdk": "^0.6.6-prerelease",
+    "@holo-host/web-sdk": "^0.6.8-prerelease",
     "@testing-library/user-event": "^13.2.1",
     "add": "^2.0.6",
     "dayjs": "^1.11.5",

--- a/src/stores/useHoloStore.js
+++ b/src/stores/useHoloStore.js
@@ -81,17 +81,16 @@ const makeUseHoloStore = ({ connectionArgs, MockWebSdk }) => defineStore('holo',
       let result
 
       try {
-        result = await client.zomeCall({
+        result = await client.callZome({
           roleId,
           zomeName,
           fnName,
           payload
-        })
+        })        
       } finally {
         useIsLoadingStore().callIsNotLoading({ zomeName, fnName })
       }
 
-      // result may be of form { type: 'ok', data: ... } or { type 'error', data: ... }, we're letting the caller deal with that
       return result
     },
 

--- a/src/stores/useHolochainStore.js
+++ b/src/stores/useHolochainStore.js
@@ -82,15 +82,8 @@ const makeUseHolochainStore = ({ installed_app_id, app_ws_url }) => defineStore(
           },
           HC_APP_TIMEOUT
         )
-
-        // Wrap the result in an ok enum to match the structure returned from chaperone
-        return {
-          type: 'ok',
-          data: result
-        }
-      } catch (e) {
-        // unthrow the error from holochain, to match the chaperone pattern of just returning the error object
-        return e
+        
+        return result
       } finally {
         useIsLoadingStore().callIsNotLoading({ zomeName, fnName })
       }

--- a/src/utils/identicon.js
+++ b/src/utils/identicon.js
@@ -100,7 +100,13 @@ export default function renderIcon (opts, canvas) {
 
   canvas.width = canvas.height = size
 
-  const cc = canvas.getContext('2d')
+  let cc
+  try {
+    cc = canvas.getContext('2d')
+  } catch (e) {
+    return // we're in a testing environment without a real canvas
+  }
+  
   if (!cc) return // we're in a testing environment without a real canvas
 
   cc.fillStyle = backgroundColor

--- a/yarn.lock
+++ b/yarn.lock
@@ -2174,10 +2174,10 @@
   resolved "https://registry.npmjs.org/@holo-host/wasm-key-manager/-/wasm-key-manager-1.0.0.tgz"
   integrity sha512-GTfeQ2iYvYYrIkuaF0QupWP/y8sdItwL6Tr1osyaU7eUsWtGfpZqDcTZny8KNDdnQAEEP2nDWZORA/Z3EMJa3w==
 
-"@holo-host/web-sdk@^0.6.6-prerelease":
-  version "0.6.6-prerelease"
-  resolved "https://registry.yarnpkg.com/@holo-host/web-sdk/-/web-sdk-0.6.6-prerelease.tgz#01fea6e2fc47f17957c98f302ba6a144f60d044b"
-  integrity sha512-ZuHGtEtevN2O9KAxBfKZOlaR/LhRA791Wo4Kv5sdU5caUBsYMkP3XH8FX20Eu2wDnMFHBNGDUPDgqlkAyIZsxA==
+"@holo-host/web-sdk@^0.6.8-prerelease":
+  version "0.6.8-prerelease"
+  resolved "https://registry.yarnpkg.com/@holo-host/web-sdk/-/web-sdk-0.6.8-prerelease.tgz#4a2b3911f7f81e9187d7cb9d1c0a23f0a9423f9e"
+  integrity sha512-mDfxf4LgX1Lk2oULmF70VD+BL8/wF9d/7yxH3qouebGSn30SkzrI/TNsqZfs19zeHVKp4Bm/FsjNfE++vcUhtg==
   dependencies:
     "@holo-host/comb" "^0.3.0"
 
@@ -2574,9 +2574,9 @@
   integrity sha512-ApwiSL2c9ObewdOE/sqt788P1C5lomBOHyO8nUBCr4ofErBCnYQ003NtJ8lS9OQZc11ximkbmgAZJjB8y6cCdA==
 
 "@msgpack/msgpack@^2.7.1":
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/@msgpack/msgpack/-/msgpack-2.7.2.tgz#f34b8aa0c49f0dd55eb7eba577081299cbf3f90b"
-  integrity sha512-rYEi46+gIzufyYUAoHDnRzkWGxajpD9vVXFQ3g1vbjrBm6P7MBmm+s/fqPa46sxa+8FOUdEuRQKaugo5a4JWpw==
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@msgpack/msgpack/-/msgpack-2.8.0.tgz#4210deb771ee3912964f14a15ddfb5ff877e70b9"
+  integrity sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==
 
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"


### PR DESCRIPTION
Updates `useHoloStore` to use web sdk `0.6.8-prerelease`

is used by https://github.com/Holo-Host/ui-common-library/pull/44