### PR TITLE
Update client store to use agent_pub_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Bug in useHoloStore that was failing to update `appInfo` and `isReady` on initialization. [(#29)]
 
 ### Changed
+- Updated useClientStore to use agent_pub_key [(#50)]
 - Modified HAppCard, HAppCardUsage, and HAppImage to support publisher portal hApp view [(#43)]
 - Updated Identicon component to have an api usable by all 3 client UIs. [(#15)]
 - Identity modal must be closed by clicking I Understand (removed option to click outside dialog to close) [(#18)]
@@ -23,3 +24,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [(#19)]: https://github.com/Holo-Host/ui-common-library/pull/19
 [(#29)]: https://github.com/Holo-Host/ui-common-library/pull/29
 [(#43)]: https://github.com/Holo-Host/ui-common-library/pull/43
+[(#50)]: https://github.com/Holo-Host/ui-common-library/pull/50

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A collection of components, stores and other javascript code for use in holo happ uis.
 
+This library includes a package.json that is only used for testing. You do NOT need to install any additional libraries to use the components in this project.
+
 ### Run tests
 ```
 npm run test

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@holo-host/identicon": "^0.1.0",
-    "@holo-host/web-sdk": "^0.6.8-prerelease",
+    "@holo-host/web-sdk": "^0.6.9-prerelease",
     "@testing-library/user-event": "^13.2.1",
     "add": "^2.0.6",
     "dayjs": "^1.11.5",

--- a/src/stores/useClientStore.js
+++ b/src/stores/useClientStore.js
@@ -19,8 +19,8 @@ const makeUseClientStore = ({ useInterfaceStore, onInit }) => defineStore('clien
         // This could be more efficient by inspecting the contents of mutation
         this.isReady = state.isReady
 
-        if (state.appInfo?.cell_data) {
-          this.setAgentKeyFromAppInfo(state.appInfo)
+        if (state.appInfo?.agent_pub_key) {
+          this.agentKey = state.appInfo.agent_pub_key
         }
       })
 
@@ -45,19 +45,6 @@ const makeUseClientStore = ({ useInterfaceStore, onInit }) => defineStore('clien
 
       return result
     },
-
-    setAgentKeyFromAppInfo(appInfo) {
-      const {
-        cell_data: [
-          {
-            cell_id: [_dnaHash, agentKey]
-          }
-        ]
-      } = appInfo
-
-      this.agentKey = agentKey
-      console.log(`setting agentKey = ${encodeAgentId(agentKey)}`)
-    }
   }
 })
 


### PR DESCRIPTION
Update UI common library to use the agent_pub_key for the agent key instead of digging through the cell data.