### PR TITLE
Fix(base-table): sorting by date fields

### DIFF
--- a/src/components/BaseTable.vue
+++ b/src/components/BaseTable.vue
@@ -39,6 +39,7 @@
 </template>
 
 <script setup>
+import dayjs from 'dayjs'
 import { computed, ref, watch } from 'vue'
 import { ESortDirections } from '../types/ui'
 import BaseCard from './BaseCard.vue'
@@ -101,6 +102,7 @@ const pageSize = ref(kDefaultPageSize)
 const currentPage = ref(0)
 
 const sortBy = ref(props.initialSortBy)
+const sortByType = ref('string')
 const sortDirection = ref(ESortDirections.desc)
 
 const isEmpty = computed(() => props.isLoading || !props.items.length || props.isError)
@@ -108,11 +110,19 @@ const isEmpty = computed(() => props.isLoading || !props.items.length || props.i
 const sortedItems = computed(() => {
   const sortKey = sortBy.value
 
-  const itemsCopy = [...props.items]
-
-  return itemsCopy.sort((a, b) => {
+  return [...props.items].sort((a, b) => {
     if (a[sortKey] === b[sortKey]) {
       return 0
+    }
+
+    if (sortByType.value === 'date') {
+      const isAfter = dayjs(a[sortKey]).isAfter(dayjs(b[sortKey]))
+
+      if (sortDirection.value === ESortDirections.desc) {
+        return isAfter ? -1 : 1
+      } else {
+        return isAfter ? 1 : -1
+      }
     }
 
     if (sortDirection.value === ESortDirections.desc) {
@@ -138,10 +148,11 @@ watch(pageSize, () => (currentPage.value = 0))
 // new data is presented
 watch(itemsCount, () => (currentPage.value = 0))
 
-function onSortByChanged({ key, direction }) {
+function onSortByChanged({ key, type, direction }) {
   sortBy.value = key
+  sortByType.value = type
   sortDirection.value = direction
-  emit('sort-by-changed', { key, direction })
+  emit('sort-by-changed', { key, type, direction })
 }
 
 function onPageChanged(page) {

--- a/src/components/BaseTable.vue
+++ b/src/components/BaseTable.vue
@@ -39,7 +39,6 @@
 </template>
 
 <script setup>
-import dayjs from 'dayjs'
 import { computed, ref, watch } from 'vue'
 import { ESortDirections } from '../types/ui'
 import BaseCard from './BaseCard.vue'
@@ -116,13 +115,9 @@ const sortedItems = computed(() => {
     }
 
     if (sortByType.value === 'date') {
-      const isAfter = dayjs(a[sortKey]).isAfter(dayjs(b[sortKey]))
-
-      if (sortDirection.value === ESortDirections.desc) {
-        return isAfter ? -1 : 1
-      } else {
-        return isAfter ? 1 : -1
-      }
+      return sortDirection.value === ESortDirections.desc
+        ? new Date(a[sortKey]).getTime() - new Date(b[sortKey]).getTime()
+        : new Date(b[sortKey]).getTime() - new Date(a[sortKey]).getTime()
     }
 
     if (sortDirection.value === ESortDirections.desc) {

--- a/src/components/BaseTableHeader.vue
+++ b/src/components/BaseTableHeader.vue
@@ -49,6 +49,7 @@ function onHeaderClicked(header) {
 
     emit('sortByChanged', {
       key: header.key,
+      type: header.type,
       direction: sortDirection.value
     })
   }


### PR DESCRIPTION
This PR fixes how the table is sorted using date values.

It was sorting the dates as strings that resulted in wrong order being returned. Now we use dayjs to check if one date is after another in the sorting logic.