### PR TITLE
Update paths for holofuel vite conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ export const useHolochainStore = makeUseHolochainStore({
   app_ws_url: 'http://localhost:8888', // path to your local hc app websocket
 })
 
-const CHAPERONE_URL = process.env.VUE_APP_CHAPERONE_SERVER_URL
-  ? process.env.VUE_APP_CHAPERONE_SERVER_URL
+const CHAPERONE_URL = import.meta.env.VITE_APP_CHAPERONE_SERVER_URL
+  ? import.meta.env.VITE_APP_CHAPERONE_SERVER_URL
   : "http://localhost:24274"
 
 export const useHoloStore = makeUseHoloStore({

--- a/src/components/IdentityModal.vue
+++ b/src/components/IdentityModal.vue
@@ -21,9 +21,9 @@
 </template>
 
 <script>
-import Button from './Button'
+import Button from './Button.vue'
 import Identicon from './Identicon.vue'
-import Modal from './Modal'
+import Modal from './Modal.vue'
 
 export default {
   name: 'IdentityModal',

--- a/src/components/Modal.vue
+++ b/src/components/Modal.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script>
-import ExIcon from './icons/ExIcon'
+import ExIcon from './icons/ExIcon.vue'
 
 export default {
   name: 'Modal',

--- a/src/components/NameSetterModal.vue
+++ b/src/components/NameSetterModal.vue
@@ -23,8 +23,8 @@
 </template>
 
 <script>
-import Button from './Button'
-import Modal from './Modal'
+import Button from './Button.vue'
+import Modal from './Modal.vue'
 
 export default {
   name: 'NameSetterModal',


### PR DESCRIPTION
This PR adds the .vue extension to a couple of imports that vite requires to compile. We were already doing this for most of our imports, but we had a handful that were missing.