### PR TITLE
Feature/base-table: add support for italic row items

### DIFF
--- a/src/components/BaseTableRowItem.vue
+++ b/src/components/BaseTableRowItem.vue
@@ -3,6 +3,7 @@
     :class="[
       { 'table-row-item__mobile-header': isVisibleOnMobile },
       { 'table-row-item--bold': isBold },
+      { 'table-row-item--italic': isItalic },
       { 'table-row-item--clickable': isClickable },
       ...classes,
     ]"
@@ -38,6 +39,11 @@ const props = defineProps({
   },
 
   isBold: {
+    type: Boolean,
+    default: false
+  },
+
+  isItalic: {
     type: Boolean,
     default: false
   },
@@ -112,6 +118,10 @@ function onClick() {
 
   &--bold {
     font-weight: bold;
+  }
+
+  &--italic {
+    font-style: italic;
   }
 
   &--clickable {


### PR DESCRIPTION
This PR allows to make the table row item italic by passing `is-italic` prop

<img width="1207" alt="Screenshot 2023-04-06 at 14 44 51" src="https://user-images.githubusercontent.com/17565389/230382316-ec23747a-08e4-4b3c-8724-aae699377006.png">
