### PR TITLE
Featurte/allow props to be passed to modal

### DIFF
--- a/src/components/BaseModal.vue
+++ b/src/components/BaseModal.vue
@@ -174,6 +174,10 @@ const emit = defineEmits(['close'])
       margin: 0 -6px;
     }
 
+    &__message-content {
+      width: 100%;
+    }
+
     &__buttons {
       padding-bottom: 10px;
     }

--- a/src/composables/useModals.js
+++ b/src/composables/useModals.js
@@ -1,19 +1,23 @@
 import { ref } from 'vue'
 
 const visibleModal = ref(null)
+const modalProps = ref({})
 
 export function useModals() {
-  function showModal(modalName) {
+  function showModal(modalName, props) {
     visibleModal.value = modalName
+    modalProps.value = props
   }
 
   function hideModal() {
     visibleModal.value = null
+    modalProps.value = {}
   }
 
   return {
     visibleModal,
     showModal,
-    hideModal
+    hideModal,
+    modalProps
   }
 }


### PR DESCRIPTION
This PR allows passing any props to the modal.

Now we can do this for example:
```
  showModal(EModal.redemption_initiated, {
    date: 1666828474041950,
    hfAmount: '1000000',
    requestId: 'dit7373ddjlg9204hfnfvu749506mvjshss7306mvjsd8',
    currency: 'HOT',
    hotAddress: '0x52908400098527886E0F7030069857D2E4169EE7',
    redemptionAmount: '1000000'
  })
```

and then read that props directly in the modal

```
const { modalProps } = useModals()
```