### PR TITLE
Add go to springboard dialog and fetch kyc level from HBS

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@testing-library/user-event": "^13.2.1",
     "@vueuse/core": "^9.13.0",
     "add": "^2.0.6",
+    "axios": "^1.4.0",
     "dayjs": "^1.11.5",
     "dotenv": "^8.2.0",
     "mitt": "^3.0.0",

--- a/src/components/GoToSpringboardModal.vue
+++ b/src/components/GoToSpringboardModal.vue
@@ -1,0 +1,96 @@
+<template>
+    <BaseModal :is-visible="visibleModal === EModal.go_to_springboard" @close="hideModal">
+        <div class="go-to-springboard-modal">
+            <img src="/images/holo-logo-2.png" class="go-to-springboard-modal__springboard-logo" alt="springboard-logo" />
+
+            <p class="go-to-springboard-modal__title">
+                Holo Springboard
+            </p>
+
+            <p class="go-to-springboard-modal__description">
+                You’re leaving Cloud Console to go to Holo Springboard, where you can upgrade your verification. 
+            </p>
+        </div>
+  
+        <template #buttons>
+            <div class="go-to-springboard-modal__buttons">
+                <BaseButton
+                :type="EButtonType.custom"
+                :custom-theme="{
+                    fontColor: 'white',
+                    backgroundColor: '#5C4DA6',
+                    spinnerColor: 'white'
+                }"
+                class="go-to-springboard-modal__button"
+                @click="handleSpringboardLogin"
+                >
+                Go to Holo Springboard
+                </BaseButton>
+            </div>
+        </template>
+    </BaseModal>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import { useModals } from '../composables/useModals'
+import { EButtonType, EModal } from '../types/ui'
+import BaseButton from './BaseButton.vue'
+import BaseModal from './BaseModal.vue'
+
+const { visibleModal, hideModal } = useModals()
+
+const props = defineProps({
+  appName: {
+    type: String,
+    required: true
+  },
+
+  springboardUrl: {
+    type: String,
+    required: true
+  }
+})
+
+const emit = defineEmits(['login'])
+
+function handleSpringboardLogin() {
+  hideModal()
+
+  emit('login')
+  const tabName = `${props.appName}-hf`
+  window.open(props.springboardUrl, tabName).focus()
+}
+
+</script>
+
+<style scoped lang="scss">
+.go-to-springboard-modal {
+  &__springboard-logo {
+    height: 50px;
+    margin: 0 auto;
+  }
+
+  &__title {
+    margin-top: 6px;
+    font-size: 26px;
+    font-weight: 600;
+    text-align: center;
+  }
+
+  &__description {
+    margin-top: 40px;
+    padding: 0 46px;
+  }
+
+  &__buttons {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__button {
+    margin-top: 8px;
+    margin-bottom: 12px;
+  }
+}
+</style>

--- a/src/services/hbs.js
+++ b/src/services/hbs.js
@@ -1,0 +1,46 @@
+import axios from 'axios'
+import { AUTH_SERVICE_URL, AUTH_SERVICE_VERSION } from '../utils/hbsConfiguration'
+import { httpCall } from '../utils/httpProvider'
+import { useHoloStore } from 'src/stores'
+
+async function authCall(args) {
+  return httpCall({
+    serviceUrl: AUTH_SERVICE_URL,
+    version: AUTH_SERVICE_VERSION,
+    method: 'post',
+    ...args
+  })
+}
+  
+  export async function authenticateAgent(email, public_key) {
+    console.log(`hbs->authenticateAgent - email: ${email} public_key: ${public_key}`)
+
+    const holoStore = useHoloStore();
+    const payload = {
+      "email": email,
+      "timestamp": Date.now() - (30 * 1000), // Subtract 30 sec to prevent "future" timestamp error from API
+      "pubKey": public_key
+    }
+
+    const { _, signature  }  = await holoStore.signPayload(payload)
+    console.log(`authenticateAgent - signature: ${signature}`, payload)
+
+    try {
+      const result = await authCall({
+        params: payload,
+        endpoint: 'holo-client',
+        headers: {
+          'X-Signature': signature
+        }
+      })
+  
+      return result.data
+    } catch (e) {
+      if (axios.isAxiosError(e)) {
+        return e.message
+      } else {
+        return 'unknown error'
+      }
+    }
+  }
+  

--- a/src/stores/useHoloBusinessServiceStore.js
+++ b/src/stores/useHoloBusinessServiceStore.js
@@ -1,20 +1,33 @@
 import { defineStore } from 'pinia'
 import { authenticateAgent } from 'src/services/hbs'
 
+const kycLevel1 = 'holo_kyc_1'
+const kycLevel2 = 'holo_kyc_2'
+
 const useHoloBusinessServiceStore = defineStore('hbs', {
   state: () => ({
-    agentKeyLevel: 0
+    agentKeyLevel: null
   }),
-  getters: {
-    isAgentKeyPopulated: state => state.agentKeyLevel > 0,
-  },
   actions: {
     async loadAgentKycLevel(email, public_key) {
-        if( ! this.isAgentAuthenticated ) {
-            const authResult = await authenticateAgent(email, public_key)
-            console.log(`agentKycLevel authResult`, authResult)
-            this.agentKeyLevel = 99
+
+      const authResult = await authenticateAgent(email, public_key)
+      if( authResult && authResult.id ) {
+        switch(authResult.kyc) {
+          case kycLevel1: {
+            this.agentKeyLevel = 1
+            break
+          }
+          case kycLevel2: {
+            this.agentKeyLevel = 2
+            break
+          }
+          default: {
+            this.agentKeyLevel = null
+          }
         }
+            
+      }
     }
   }
 })

--- a/src/stores/useHoloBusinessServiceStore.js
+++ b/src/stores/useHoloBusinessServiceStore.js
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
-import { authenticateAgent } from 'src/services/hbs'
+// import { authenticateAgent } from 'src/services/hbs'
+import { authenticateAgent } from "@uicommon/services/hbs"
 
 const kycLevel1 = 'holo_kyc_1'
 const kycLevel2 = 'holo_kyc_2'

--- a/src/stores/useHoloBusinessServiceStore.js
+++ b/src/stores/useHoloBusinessServiceStore.js
@@ -12,7 +12,7 @@ const useHoloBusinessServiceStore = defineStore('hbs', {
     async loadAgentKycLevel(email, public_key) {
 
       const authResult = await authenticateAgent(email, public_key)
-      if( authResult && authResult.id ) {
+      if( authResult && authResult.kyc ) {
         switch(authResult.kyc) {
           case kycLevel1: {
             this.agentKeyLevel = 1

--- a/src/stores/useHoloBusinessServiceStore.js
+++ b/src/stores/useHoloBusinessServiceStore.js
@@ -1,0 +1,22 @@
+import { defineStore } from 'pinia'
+import { authenticateAgent } from 'src/services/hbs'
+
+const useHoloBusinessServiceStore = defineStore('hbs', {
+  state: () => ({
+    agentKeyLevel: 0
+  }),
+  getters: {
+    isAgentKeyPopulated: state => state.agentKeyLevel > 0,
+  },
+  actions: {
+    async loadAgentKycLevel(email, public_key) {
+        if( ! this.isAgentAuthenticated ) {
+            const authResult = await authenticateAgent(email, public_key)
+            console.log(`agentKycLevel authResult`, authResult)
+            this.agentKeyLevel = 99
+        }
+    }
+  }
+})
+
+export default useHoloBusinessServiceStore

--- a/src/stores/useHoloBusinessServiceStore.js
+++ b/src/stores/useHoloBusinessServiceStore.js
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia'
-// import { authenticateAgent } from 'src/services/hbs'
-import { authenticateAgent } from "@uicommon/services/hbs"
+import { authenticateAgent } from "../services/hbs"
 
 const kycLevel1 = 'holo_kyc_1'
 const kycLevel2 = 'holo_kyc_2'

--- a/src/stores/useHoloStore.js
+++ b/src/stores/useHoloStore.js
@@ -21,7 +21,8 @@ const makeUseHoloStore = ({ connectionArgs, MockWebSdk }) => defineStore('holo',
     isLoggedIn: state => state.agentState && state.agentState.isAnonymous === false && state.agentState.isAvailable === true,
     error: state => state.agentState && !state.agentState.isAvailable && (state.connectionError || state.agentState.unrecoverableError),
     agentKey: (state) => state.appInfo?.agent_pub_key,
-    agentId: state => state.agentState?.id
+    agentId: state => state.agentState?.id,
+    // XYZZY add email to agent state, and add getter to useHoloStore
   },
   actions: {
     async initialize() {
@@ -97,6 +98,10 @@ const makeUseHoloStore = ({ connectionArgs, MockWebSdk }) => defineStore('holo',
     async loadAppInfo() {
       this.appInfo = await client.appInfo()
       return this.appInfo
+    },
+
+    async signPayload(payload) {
+      return await client.signPayload(payload)
     }
 
   }

--- a/src/stores/useHoloStore.js
+++ b/src/stores/useHoloStore.js
@@ -22,7 +22,7 @@ const makeUseHoloStore = ({ connectionArgs, MockWebSdk }) => defineStore('holo',
     error: state => state.agentState && !state.agentState.isAvailable && (state.connectionError || state.agentState.unrecoverableError),
     agentKey: (state) => state.appInfo?.agent_pub_key,
     agentId: state => state.agentState?.id,
-    // XYZZY add email to agent state, and add getter to useHoloStore
+    agentEmail: state => state.agentState?.email
   },
   actions: {
     async initialize() {

--- a/src/utils/consts.js
+++ b/src/utils/consts.js
@@ -1,0 +1,8 @@
+export const Environment = {
+    local: 'local',
+    localNoBackend: 'local-no-backend',
+    development: 'development',
+    qa: 'qa',
+    production: 'production'
+}
+  

--- a/src/utils/hbsConfiguration.js
+++ b/src/utils/hbsConfiguration.js
@@ -7,8 +7,8 @@ const HbsServiceURL = (service, key, port) => {
         return `http://localhost:${port}/${service}`
   
       case Environment.localNoBackend:
-        // return `https://hbs.dev.holotest.net/${service}`
-        return `http://localhost:3001/${service}`
+        return `https://hbs.dev.holotest.net/${service}`
+        // return `http://localhost:3001/${service}`
   
       case Environment.development:
         return `https://hbs.dev.holotest.net/${service}`

--- a/src/utils/hbsConfiguration.js
+++ b/src/utils/hbsConfiguration.js
@@ -1,0 +1,44 @@
+import { Environment } from './consts'
+
+// HBS URLs:
+const HbsServiceURL = (service, key, port) => {
+    switch (key) {
+      case Environment.local:
+        return `http://localhost:${port}/${service}`
+  
+      case Environment.localNoBackend:
+        // return `https://hbs.dev.holotest.net/${service}`
+        return `http://localhost:3001/${service}`
+  
+      case Environment.development:
+        return `https://hbs.dev.holotest.net/${service}`
+  
+      case Environment.qa:
+        return `https://hbs.qa.holotest.net/${service}`
+  
+      case Environment.production:
+        return `https://hbs.holo.host/${service}`
+  
+      default:
+        throw new Error('Error resolving service url. Found invalid environment key.')
+    }
+  }
+
+  export const AUTH_SERVICE_URL = HbsServiceURL(
+    'auth',
+    process.env.VUE_ENV || Environment.localNoBackend,
+    process.env.VUE_OPS_SERVICE_PORT || '3003'
+  )
+  
+  const AuthServiceVersion = {
+    [Environment.local]: 'v1',
+    [Environment.development]: 'v1',
+    [Environment.qa]: 'v1',
+    [Environment.production]: 'v1'
+  }
+  
+  export const AUTH_SERVICE_VERSION = process.env.VUE_ENV
+    ? AuthServiceVersion[process.env.VUE_ENV]
+    : AuthServiceVersion[Environment.local]
+  
+  

--- a/src/utils/httpProvider.js
+++ b/src/utils/httpProvider.js
@@ -1,0 +1,41 @@
+import axios from 'axios'
+
+const REQUEST_TIMEOUT = 10000
+
+
+export async function httpCall({
+  serviceUrl,
+  version = 'v1',
+  method = 'get',
+  endpoint = '',
+  headers = {},
+  params = {},
+  query = '',
+  isRaw = false
+}) {
+  let url = isRaw ? serviceUrl ?? '' : `${serviceUrl}/api/${version}/${endpoint}`
+
+  if (query) {
+    url = `${url}${query}`
+  }
+
+  switch (method) {
+    case 'get':
+      return axios.get(url, { params, headers, timeout: REQUEST_TIMEOUT })
+
+    case 'post':
+      return axios.post(url, params, { headers, timeout: REQUEST_TIMEOUT })
+
+    case 'patch':
+      return axios.patch(url, params, { headers, timeout: REQUEST_TIMEOUT })
+
+    case 'put':
+      return axios.put(url, params, { headers, timeout: REQUEST_TIMEOUT })
+
+    case 'delete':
+      return axios.delete(url, { params, headers, timeout: REQUEST_TIMEOUT })
+
+    default:
+      throw new Error(`No case in httpProvider for ${method} method`)
+  }
+}


### PR DESCRIPTION
Link to [ticket](https://www51.v1host.com/Holo/story.mvc/Summary?oidToken=Story%3A74073) in agility.

- Add HBS configuration and methods to authenticate and fetch agent's kyc level
- 
![image](https://github.com/Holo-Host/ui-common-library/assets/16830873/458471b9-999c-4d71-b5f7-7181a9ca0ca5)

- Add go to springboard dialog
- 
<img width="435" alt="image" src="https://github.com/Holo-Host/ui-common-library/assets/16830873/78ef7d52-46d3-4d61-a7f1-db74574c9a76">

- Add agent email and signPayload method to holostore 