### PR TITLE
B06148 UI tweaks - rename bandwidth to data transfer

### DIFF
--- a/src/components/HAppCardUsage.vue
+++ b/src/components/HAppCardUsage.vue
@@ -30,14 +30,14 @@ const items = computed(() => {
       unit: t('$.cpu'),
       isDisabled: true
     },
-    {
-      value: presentBytes(props.happ.storage),
-      unit: t('$.storage'),
-      isDisabled: true
-    },
+    // {
+    //   value: presentBytes(props.happ.storage),
+    //   unit: t('$.storage'),
+    //   isDisabled: true
+    // },
     {
       value: presentBytes(props.happ.usage?.bandwidth),
-      unit: t('$.bandwidth'),
+      unit: t('$.data_transfer'),
       isDisabled: false
     }
   ]

--- a/src/components/HAppCardUsage.vue
+++ b/src/components/HAppCardUsage.vue
@@ -36,7 +36,7 @@ const items = computed(() => {
     //   isDisabled: true
     // },
     {
-      value: presentBytes(props.happ.usage?.bandwidth),
+      value: presentBytes(props.happ.usage?.data_transfer),
       unit: t('$.data_transfer'),
       isDisabled: false
     }

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1,7 +1,7 @@
 const translations = {
   $: {
     app_version: '{app} version {version}',
-    bandwidth: 'Bandwidth',
+    data_transfer: 'Data Transfer',
     cancel: 'Cancel',
     confirm: 'Confirm',
     continue: 'Continue',

--- a/src/stories/mocks.js
+++ b/src/stories/mocks.js
@@ -256,7 +256,7 @@ export const hAppMock = {
   isPaused: false,
   enabled: true,
   sourceChains: 0,
-  usage: { bandwidth: 0, cpu: 0 },
+  usage: { data_transfer: 0, cpu: 0 },
   storage: 0
 }
 


### PR DESCRIPTION
Link to [ticket in agility](https://www51.v1host.com/Holo/story.mvc/Summary?oidToken=Story%3A83679&RoomContext=TeamRoom%3A5802&concept=TeamRoom)

- Rename hApp card bandwidth field to data transfer
- Adjust underlying data to use data_transfer instead of bandwidth
- Hide storage usage stat (temporary)

![image](https://github.com/Holo-Host/ui-common-library/assets/16830873/30c5f712-c6c9-4df3-bb6e-d7c3316b8b6f)
