### PR TITLE
B-06148 Change bandwidth text to data transfer. Hide storage metrics.

### DIFF
--- a/src/components/HAppCardUsage.vue
+++ b/src/components/HAppCardUsage.vue
@@ -31,15 +31,15 @@ const items = computed(() => {
       isDisabled: true
     },
     {
-      value: presentBytes(props.happ.storage),
-      unit: t('$.storage'),
-      isDisabled: true
-    },
-    {
       value: presentBytes(props.happ.usage?.bandwidth),
-      unit: t('$.bandwidth'),
+      unit: t('$.data_transfer'),
       isDisabled: false
-    }
+    },
+    // {
+    //   value: presentBytes(props.happ.storage),
+    //   unit: t('$.storage'),
+    //   isDisabled: true
+    // }
   ]
 })
 </script>

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1,7 +1,7 @@
 const translations = {
   $: {
     app_version: '{app} version {version}',
-    bandwidth: 'Bandwidth',
+    data_transfer: 'Data Transfer',
     cancel: 'Cancel',
     confirm: 'Confirm',
     continue: 'Continue',


### PR DESCRIPTION
Link to [ticket in agility](https://www51.v1host.com/Holo/story.mvc/Summary?oidToken=Story%3A83679&RoomContext=TeamRoom%3A5802&concept=TeamRoom)

- Rename **bandwidth** text to **data transfer** on hApp usage metrics
- Hide storage metrics on hApp card view

![image](https://github.com/Holo-Host/ui-common-library/assets/16830873/785e6b1e-4c1e-41bb-a882-425269bdaf67)
