### PR TITLE
Feature/enable details link

### DIFF
--- a/src/components/HAppCard.vue
+++ b/src/components/HAppCard.vue
@@ -32,7 +32,11 @@
           </slot>
 
           <slot name="link-icon">
-            <ArrowIcon class="happ-card__name-arrow-icon" />
+            <ArrowIcon
+              class="happ-card__name-arrow-icon"
+              :class="[areDetailsAvailable ? 'pointer' : 'disabled']"
+              @click="emit('details-link-click')"
+            />
           </slot>
         </div>
 
@@ -63,6 +67,11 @@ const props = defineProps({
     default: () => {}
   },
 
+  areDetailsAvailable: {
+    type: Boolean,
+    default: false
+  },
+
   isEmpty: {
     type: Boolean,
     default: false
@@ -74,12 +83,13 @@ const props = defineProps({
   }
 })
 
+const emit = defineEmits(['details-link-click'])
+
 const earnings = computed(() =>
   props.happ.last7daysEarnings && Number(props.happ.last7daysEarnings)
     ? formatCurrency(Number(props.happ.last7daysEarnings))
     : '--'
 )
-
 </script>
 
 <style lang="scss" scoped>
@@ -135,7 +145,6 @@ const earnings = computed(() =>
 
     &-arrow-icon {
       margin-left: auto;
-      opacity: 0.2;
     }
   }
 
@@ -150,6 +159,10 @@ const earnings = computed(() =>
 /* Temporary, remove once we have all live data */
 .disabled {
   opacity: 0.2;
+}
+
+.pointer {
+  cursor: pointer;
 }
 
 .bold {

--- a/src/components/HAppCard.vue
+++ b/src/components/HAppCard.vue
@@ -35,7 +35,7 @@
             <ArrowIcon
               class="happ-card__name-arrow-icon"
               :class="[areDetailsAvailable ? 'pointer' : 'disabled']"
-              @click="emit('details-link-click')"
+              @click="areDetailsAvailable ? emit('details-link-click') : () => {}"
             />
           </slot>
         </div>

--- a/src/stories/HAppCard.stories.js
+++ b/src/stories/HAppCard.stories.js
@@ -9,7 +9,8 @@ export default {
   argTypes: {
     happ: hAppMock,
     isEmpty: false,
-    emptyCardLabel: ''
+    emptyCardLabel: '',
+    areDetailsAvailable: false
   }
 }
 
@@ -25,14 +26,24 @@ export const Default = kTemplate.bind({})
 Default.args = {
   happ: hAppMock,
   isEmpty: false,
-  emptyCardLabel: ''
+  emptyCardLabel: '',
+  areDetailsAvailable: false
 }
 
 export const EmptyWithLabel = kTemplate.bind({})
 EmptyWithLabel.args = {
   happ: null,
   isEmpty: true,
-  emptyCardLabel: '$.errors.no_data'
+  emptyCardLabel: '$.errors.no_data',
+  areDetailsAvailable: false
+}
+
+export const WithEnabledLink = kTemplate.bind({})
+WithEnabledLink.args = {
+  happ: hAppMock,
+  isEmpty: false,
+  emptyCardLabel: '',
+  areDetailsAvailable: true
 }
 
 const kEmptyWithCustomContentTemplate = (args) => ({


### PR DESCRIPTION
This PR enables the "Details Link" on HAppCard by passing `areDetailsAvailable` props. Then the component emits an `details-link-click` event when clicked.

<img width="628" alt="Screenshot 2023-10-23 at 22 08 15" src="https://github.com/Holo-Host/host-console-ui/assets/17565389/d2dc341e-db13-49cf-97b2-68cd2161eff5">