### PR TITLE
Feature/base-modal: make the content padding adjustable

### DIFF
--- a/src/components/BaseButton.vue
+++ b/src/components/BaseButton.vue
@@ -48,7 +48,7 @@ const props = defineProps({
     type: Number,
     default: EButtonType.primary,
     validator(value) {
-      return [EButtonType.primary, EButtonType.secondary, EButtonType.gray, EButtonType.custom].includes(value)
+      return [EButtonType.primary, EButtonType.secondary, EButtonType.tertiary, EButtonType.gray, EButtonType.custom].includes(value)
     }
   },
 

--- a/src/components/BaseModal.vue
+++ b/src/components/BaseModal.vue
@@ -14,7 +14,12 @@
           <ExIcon class="ex-icon" :size="16" />
         </button>
 
-        <div class="base-modal__content">
+        <div
+          class="base-modal__content"
+          :class="{
+            'base-modal__content--small-padding': contentPadding === 'sm',
+          }"
+        >
           <span v-if="title" class="base-modal__title">
             {{ title }}
           </span>
@@ -63,6 +68,14 @@ defineProps({
   subTitle: {
     type: String,
     default: ''
+  },
+
+  contentPadding: {
+    type: String,
+    default: 'md',
+    validator(value) {
+      return ['sm', 'md'].includes(value)
+    }
   }
 })
 
@@ -79,7 +92,7 @@ const emit = defineEmits(['close'])
   z-index: 20;
   padding: 26px;
   opacity: 1;
-  max-width: 580px;
+  max-width: 640px;
 
   &__overlay {
     position: fixed;
@@ -105,6 +118,10 @@ const emit = defineEmits(['close'])
     line-height: 19px;
     text-align: center;
     color: #313c59;
+
+    &--small-padding {
+      padding: 26px 12px;
+    }
   }
 
   &__title {
@@ -161,6 +178,10 @@ const emit = defineEmits(['close'])
 
     &__sub-title {
       margin-bottom: 26px;
+    }
+
+    &__buttons {
+      margin-top: 32px;
     }
   }
 }


### PR DESCRIPTION
This PR:

- `BaseModal`:
  - allows to pass `contentPadding` property to the component that makes the padding adjustable.
     Use case: It allows to fit more content without wrapping.
<img width="724" alt="Screenshot 2023-11-03 at 11 27 35" src="https://github.com/Holo-Host/ui-common-library/assets/17565389/3ac5da0e-90d3-49fa-9777-be9f97f9c0f8">
 
  - adds a space between content and button on mobile devices
<img width="364" alt="Screenshot 2023-11-03 at 11 29 43" src="https://github.com/Holo-Host/ui-common-library/assets/17565389/a04555a7-f9c2-487c-b942-6ba36641068e">


- `BaseButton`:
  - fixes the warning when `EButtonType.tertiary` is passed

