### PR TITLE
feat(base-modal): add prop to disable close on click outside

### DIFF
--- a/src/components/BaseModal.vue
+++ b/src/components/BaseModal.vue
@@ -3,7 +3,7 @@
     <div
       v-if="isVisible"
       class="base-modal__overlay"
-      @click="isDismissible ? emit('close') : () => {}"
+      @click="isDismissible && isClickableOutside ? emit('close') : () => {}"
     >
       <div class="base-modal" @click.stop>
         <button
@@ -46,6 +46,11 @@ import ExIcon from './icons/ExIcon.vue'
 
 defineProps({
   hasCloseButton: {
+    type: Boolean,
+    default: true
+  },
+
+  isClickableOutside: {
     type: Boolean,
     default: true
   },


### PR DESCRIPTION
This PR adds a `isClickableOutside` prop to BaseModal that allows to control if the modal should close on click outside event.