### PR TITLE
Use hbsStore for kyc in holofuel and clean-up clientStore.

### DIFF
--- a/src/services/hpos.js
+++ b/src/services/hpos.js
@@ -1,0 +1,50 @@
+import axios from 'axios'
+
+export const hposHolochainCall = async ({
+    path,
+    headers: userHeaders = {},
+    params,
+    method = 'post',
+  }) => {
+    const axiosConfig = {
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*'
+      }
+    }
+
+    const HPOS_API_URL = `${window.location.protocol}//${window.location.host}`
+    const pathPrefix = '/holochain-api/v1/'
+    const fullUrl = `${HPOS_API_URL}${pathPrefix}${path}`
+
+    const authToken = localStorage.getItem('authToken')
+
+    const headers = {
+      'X-Hpos-Auth-Token': authToken,
+      ...axiosConfig.headers,
+      ...userHeaders
+    }
+
+    let response
+
+    switch (method) {
+      case 'get':
+        response = await axios.get(fullUrl, { params, headers })
+        return response.data
+
+      case 'post':
+        response = await axios.post(fullUrl, params, { headers })
+        return response.data
+
+      case 'put':
+        response = await axios.put(fullUrl, params, { headers })
+        return response.data
+
+      case 'delete':
+        response = await axios.delete(fullUrl, { params, headers })
+        return response.data
+
+      default:
+        throw new Error(`No case in hposCall for ${method} method`)
+      }
+  }

--- a/src/stores/useClientStore.js
+++ b/src/stores/useClientStore.js
@@ -2,7 +2,7 @@ import { inspect } from 'util'
 import { defineStore } from 'pinia'
 import { encodeAgentId } from '../utils/agent'
 
-const makeUseClientStore = ({ useInterfaceStore, onInit }) => defineStore('client', {
+const makeUseClientStore = ({ useInterfaceStore, onInit, loadKycLevel }) => defineStore('client', {
   state: () => ({
     agentKey: null, // the Uint8Array of raw bytes. See also agentId in getters, below
     isReady: false,
@@ -49,7 +49,7 @@ const makeUseClientStore = ({ useInterfaceStore, onInit }) => defineStore('clien
     },
 
     async loadAgentKycLevel(environment, hbsServicePort) {
-      const kycLevel = await useInterfaceStore().loadAgentKycLevel(environment, hbsServicePort)
+      const kycLevel = await loadKycLevel(environment, hbsServicePort)
       this.agentKyc = kycLevel
       return kycLevel
     }

--- a/src/stores/useClientStore.js
+++ b/src/stores/useClientStore.js
@@ -2,7 +2,7 @@ import { inspect } from 'util'
 import { defineStore } from 'pinia'
 import { encodeAgentId } from '../utils/agent'
 
-const makeUseClientStore = ({ useInterfaceStore, onInit, loadKycLevel }) => defineStore('client', {
+const makeUseClientStore = ({ useInterfaceStore, onInit, fetchKycLevel }) => defineStore('client', {
   state: () => ({
     agentKey: null, // the Uint8Array of raw bytes. See also agentId in getters, below
     isReady: false,
@@ -49,7 +49,7 @@ const makeUseClientStore = ({ useInterfaceStore, onInit, loadKycLevel }) => defi
     },
 
     async loadAgentKycLevel(environment, hbsServicePort) {
-      const kycLevel = await loadKycLevel(environment, hbsServicePort)
+      const kycLevel = await fetchKycLevel(environment, hbsServicePort)
       this.agentKyc = kycLevel
       return kycLevel
     }

--- a/src/stores/useHbsStore.js
+++ b/src/stores/useHbsStore.js
@@ -21,6 +21,7 @@ const makeUseHbsStore = ({ useHoloStore }) => {
             
                 const { _, signature  } = await await useHoloStore().signPayload(payload)
                 const kycLevel = await fetchAgentKycLevel(payload, signature, environment, hbsServicePort)
+                console.log(`🚁 HBS loadAgentKycLevel KYC level: ${kycLevel}`)
                 this.kycLevel = kycLevel
                 return kycLevel
             },

--- a/src/stores/useHbsStore.js
+++ b/src/stores/useHbsStore.js
@@ -21,7 +21,6 @@ const makeUseHbsStore = ({ useHoloStore }) => {
             
                 const { _, signature  } = await await useHoloStore().signPayload(payload)
                 const kycLevel = await fetchAgentKycLevel(payload, signature, environment, hbsServicePort)
-                console.log(`🚁 HBS loadAgentKycLevel KYC level: ${kycLevel}`)
                 this.kycLevel = kycLevel
                 return kycLevel
             },

--- a/src/stores/useHoloStore.js
+++ b/src/stores/useHoloStore.js
@@ -3,8 +3,6 @@ import { defineStore } from 'pinia'
 import useIsLoadingStore from './useIsLoadingStore'
 import useSignalStore from './useSignalStore'
 
-const msgpack = require('@msgpack/msgpack')
-
 let client
 
 const makeUseHoloStore = ({ connectionArgs, MockWebSdk }) => defineStore('holo', {

--- a/src/stores/useHolochainStore.js
+++ b/src/stores/useHolochainStore.js
@@ -123,7 +123,7 @@ const makeUseHolochainStore = ({ installed_app_id, app_ws_url, hc_admin_port }) 
         resolve()
       })
     },
-    async loadAgentKycLevel(_, __) {
+    async fetchAgentKycLevel(_, __) {
       const kycLevel = await hposHolochainCall({path: 'kyc', headers: {}, params: {}, method: 'get'})
       return kycLevel ? (kycLevel === kycLevel2) ? 2 : 1 : null
     },

--- a/src/stores/useHolochainStore.js
+++ b/src/stores/useHolochainStore.js
@@ -1,15 +1,15 @@
 import { inspect } from 'util'
-import axios from 'axios'
 import { AdminWebsocket, AppWebsocket, generateSigningKeyPair, setSigningCredentials } from '@holochain/client'
 import { defineStore } from 'pinia'
 import { presentHcSignal, listify } from '../utils'
 import useIsLoadingStore from './useIsLoadingStore'
 import useSignalStore from './useSignalStore'
 import { kycLevel2 } from '../services/hbs'
+import { hposHolochainCall } from '../services/hpos'
 
 const HC_APP_TIMEOUT = 35_000
 
-const makeUseHolochainStore = ({ installed_app_id, app_ws_url, is_hpos_served, hc_admin_port }) => defineStore('holochain', {
+const makeUseHolochainStore = ({ installed_app_id, app_ws_url, hc_admin_port }) => defineStore('holochain', {
   state: () => ({
     client: null,
     // These two values are subscribed to by clientStore
@@ -110,18 +110,6 @@ const makeUseHolochainStore = ({ installed_app_id, app_ws_url, is_hpos_served, h
 
       return result
     },
-    async zomeCall(args) {
-      const zomeCallArgs = {
-        appId: installed_app_id,
-        roleId: args.role_name,
-        zomeName: args.zome_name,
-        fnName: args.fn_name,
-        payload: args.payload
-      }
-
-      const response = await this.hposHolochainCall({path: 'zome_call', headers: {}, params: zomeCallArgs})
-      return response
-    },    
     setCredentials(cellId) {
       this.signingCredentials = new Promise(async (resolve, reject) => {
         try {
@@ -135,60 +123,8 @@ const makeUseHolochainStore = ({ installed_app_id, app_ws_url, is_hpos_served, h
         resolve()
       })
     },
-    async hposHolochainCall({
-      path,
-      headers: userHeaders = {},
-      params,
-      method = 'post',
-    }) {
-      const axiosConfig = {
-        headers: {
-          'Content-Type': 'application/json',
-          'Access-Control-Allow-Origin': '*'
-        }
-      }
-
-      const HPOS_API_URL = `${window.location.protocol}//${window.location.host}`
-      const pathPrefix = '/holochain-api/v1/'
-      const fullUrl = `${HPOS_API_URL}${pathPrefix}${path}`
-
-      const authToken = localStorage.getItem('authToken')
-
-      const headers = {
-        'X-Hpos-Auth-Token': authToken,
-        ...axiosConfig.headers,
-        ...userHeaders
-      }
-
-      let response
-
-      switch (method) {
-        case 'get':
-          response = await axios.get(fullUrl, { params, headers })
-          return response.data
-
-        case 'post':
-          response = await axios.post(fullUrl, params, { headers })
-          return response.data
-
-        case 'put':
-          response = await axios.put(fullUrl, params, { headers })
-          return response.data
-
-        case 'delete':
-          response = await axios.delete(fullUrl, { params, headers })
-          return response.data
-
-        default:
-          throw new Error(`No case in hposCall for ${method} method`)
-        }
-    },    
     async loadAgentKycLevel(_, __) {
-      if( !is_hpos_served) {
-        return null // raw holochain doesn't have a mechanism for retrieving agent's kyc
-      }
-      
-      const kycLevel = await this.hposHolochainCall({path: 'kyc', headers: {}, params: {}, method: 'get'})
+      const kycLevel = await hposHolochainCall({path: 'kyc', headers: {}, params: {}, method: 'get'})
       return kycLevel ? (kycLevel === kycLevel2) ? 2 : 1 : null
     },
   }


### PR DESCRIPTION
- Pull HPOS service call logic from useHolochain store and move to services folder
- useClient store takes a loadKycLevel function that fetches the kyc level from hbsStore or HPOS
- remove isHPOSServed from useHolochain store
- remove unused hposHolochain calls from useHolochain store